### PR TITLE
Add a user context.

### DIFF
--- a/alini.c
+++ b/alini.c
@@ -88,6 +88,18 @@ int alini_parser_setcallback_foundkvpair(alini_parser_t *parser, alini_parser_fo
 	return 0;
 }
 
+void alini_parser_set_context(alini_parser_t *parser, void *ctx)
+{
+	assert(parser);
+	parser->ctx = ctx;
+}
+
+void *alini_parser_get_context(alini_parser_t *parser)
+{
+	assert(parser);
+	return parser->ctx;
+}
+
 /* parse one step */
 int alini_parser_step(alini_parser_t *parser)
 {

--- a/alini.h
+++ b/alini.h
@@ -41,6 +41,7 @@ struct alini_parser_s {
 	char *activesection;
 	FILE *file;
 	alini_parser_foundkvpair_callback foundkvpair_callback;
+	void *ctx;
 };
 
 /* create parser */
@@ -48,6 +49,12 @@ int alini_parser_create(alini_parser_t **parser, char *path);
 
 /* set `found key-value pair` callback */
 int alini_parser_setcallback_foundkvpair(alini_parser_t *parser, alini_parser_foundkvpair_callback callback);
+
+/* set user context */
+void alini_parser_set_context(alini_parser_t *parser, void *ctx);
+
+/* get user context */
+void *alini_parser_get_context(alini_parser_t *parser);
 
 /* parse one step */
 int alini_parser_step(alini_parser_t *parser);


### PR DESCRIPTION
So that we aren't forced to use global variables. With this the user can create the parser, set the user context. And then in the parse callback, get that context and save the parse results in there.
